### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.2](https://github.com/sermuns/skrytsam/compare/v0.1.1...v0.1.2) - 2026-01-30
+
+### Fixed
+
+- *(ci)* openssl sys vendored for musl
+
+### Other
+
+- bump some deps
+
 ## [0.1.1](https://github.com/sermuns/skrytsam/compare/v0.1.0...v0.1.1) - 2026-01-30
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "skrytsam"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "skrytsam"
 description = "generate pretty svgs for your profile on GitHub"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 repository = "https://github.com/sermuns/skrytsam"
 license = "WTFPL"


### PR DESCRIPTION



## 🤖 New release

* `skrytsam`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/sermuns/skrytsam/compare/v0.1.1...v0.1.2) - 2026-01-30

### Fixed

- *(ci)* openssl sys vendored for musl

### Other

- bump some deps
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).