### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.4](https://github.com/sermuns/skrytsam/compare/v0.1.3...v0.1.4) - 2026-02-04
+
+### Added
+
+- embed EVERYTHING at compiletime
+
+### Other
+
+- build with verbose
+
 ## [0.1.3](https://github.com/sermuns/skrytsam/compare/v0.1.2...v0.1.3) - 2026-01-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "skrytsam"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "skrytsam"
 description = "generate pretty svgs for your profile on GitHub"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 repository = "https://github.com/sermuns/skrytsam"
 license = "WTFPL"


### PR DESCRIPTION



## 🤖 New release

* `skrytsam`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/sermuns/skrytsam/compare/v0.1.3...v0.1.4) - 2026-02-04

### Added

- embed EVERYTHING at compiletime

### Other

- build with verbose
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).