### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.5](https://github.com/sermuns/skrytsam/compare/v0.1.4...v0.1.5) - 2026-02-04
+
+### Fixed
+
+- cache in a place we have permissions
+
+### Other
+
+- build for more linux arches. FIX where it was not including fonts, had to use git-lfs...
+
 ## [0.1.4](https://github.com/sermuns/skrytsam/compare/v0.1.3...v0.1.4) - 2026-02-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "skrytsam"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "skrytsam"
 description = "generate pretty svgs for your profile on GitHub"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 repository = "https://github.com/sermuns/skrytsam"
 license = "WTFPL"


### PR DESCRIPTION



## 🤖 New release

* `skrytsam`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/sermuns/skrytsam/compare/v0.1.4...v0.1.5) - 2026-02-04

### Fixed

- cache in a place we have permissions

### Other

- build for more linux arches. FIX where it was not including fonts, had to use git-lfs...
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).