### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.2.0](https://github.com/sermuns/skrytsam/compare/v0.1.5...v0.2.0) - 2026-02-07
+
+### Added
+
+- [**breaking**] change default values for flags
+- add --skip-archived
+- [**breaking**] change to subcommands, add `languages`
+
+### Other
+
+- use less specific versions
+- use typst-bake git
+- remove unused imports
+- remove usage from README
+
 ## [0.1.5](https://github.com/sermuns/skrytsam/compare/v0.1.4...v0.1.5) - 2026-02-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3104,7 +3104,7 @@ dependencies = [
 
 [[package]]
 name = "skrytsam"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "skrytsam"
 description = "generate pretty svgs for your profile on GitHub"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2024"
 repository = "https://github.com/sermuns/skrytsam"
 license = "WTFPL"


### PR DESCRIPTION



## 🤖 New release

* `skrytsam`: 0.1.5 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/sermuns/skrytsam/compare/v0.1.5...v0.2.0) - 2026-02-07

### Added

- [**breaking**] change default values for flags
- add --skip-archived
- [**breaking**] change to subcommands, add `languages`

### Other

- use less specific versions
- use typst-bake git
- remove unused imports
- remove usage from README
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).