### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.2.1](https://github.com/sermuns/skrytsam/compare/v0.2.0...v0.2.1) - 2026-02-07
+
+### Added
+
+- concurrently fetch pages of repos
+
+### Other
+
+- use correct parameter..
+
 ## [0.2.0](https://github.com/sermuns/skrytsam/compare/v0.1.5...v0.2.0) - 2026-02-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "skrytsam"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "skrytsam"
 description = "generate pretty svgs for your profile on GitHub"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 repository = "https://github.com/sermuns/skrytsam"
 license = "WTFPL"


### PR DESCRIPTION



## 🤖 New release

* `skrytsam`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/sermuns/skrytsam/compare/v0.2.0...v0.2.1) - 2026-02-07

### Added

- concurrently fetch pages of repos

### Other

- use correct parameter..
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).