### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.2.2](https://github.com/sermuns/skrytsam/compare/v0.2.1...v0.2.2) - 2026-02-13
+
+### Added
+
+- allow stdout output with `-o -`
+
+### Other
+
+- add prek present task
+- use less default features. use serde_saphyr, use latest typst-bake
+
 ## [0.2.1](https://github.com/sermuns/skrytsam/compare/v0.2.0...v0.2.1) - 2026-02-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "skrytsam"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "skrytsam"
 description = "generate pretty svgs for your profile on GitHub"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 repository = "https://github.com/sermuns/skrytsam"
 license = "WTFPL"


### PR DESCRIPTION



## 🤖 New release

* `skrytsam`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/sermuns/skrytsam/compare/v0.2.1...v0.2.2) - 2026-02-13

### Added

- allow stdout output with `-o -`

### Other

- add prek present task
- use less default features. use serde_saphyr, use latest typst-bake
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).